### PR TITLE
Update to DurationUtil.cs to correct minor display issue

### DIFF
--- a/source/ContractConfigurator/DurationUtil.cs
+++ b/source/ContractConfigurator/DurationUtil.cs
@@ -64,12 +64,12 @@ namespace ContractConfigurator
             string output = "";
             if (years != 0)
             {
-                output += years + (years == 1 ? "year" : " years");
+                output += years + (years == 1 ? " year" : " years");
             }
             if (days != 0)
             {
                 if (output.Length != 0) output += ", ";
-                output += days + (days == 1 ? "days" : " days");
+                output += days + (days == 1 ? " day" : " days");
             }
             if (hours != 0 || minutes != 0 || seconds != 0 || output.Length == 0)
             {
@@ -100,12 +100,12 @@ namespace ContractConfigurator
 
                 if (years != 0)
                 {
-                    output += years + (years == 1 ? "year" : " years");
+                    output += years + (years == 1 ? " year" : " years");
                 }
                 if (days != 0)
                 {
                     if (output.Length != 0) output += ", ";
-                    output += days + (days == 1 ? "days" : " days");
+                    output += days + (days == 1 ? " day" : " days");
                 }
             }
 


### PR DESCRIPTION
In the current version when selecting a day or year as the duration, it is displayed as "1days" or "1year" instead of "1 day" or "1 year". Also when picking a duration of 1 year and 1 day is displays as "1year, 1days" instead of "1 year, 1 day".

Never made a fork or issued a pull request before so don't hurt me, but I think I changed it correctly.

Fixes this

http://i.imgur.com/EfJugQH.png