### PR TITLE
Static method to return the ContractType name for a given ConfiguredContract

### DIFF
--- a/source/ContractConfigurator/ConfiguredContract.cs
+++ b/source/ContractConfigurator/ConfiguredContract.cs
@@ -21,6 +21,27 @@ namespace ContractConfigurator
         private List<ContractBehaviour> behaviours = new List<ContractBehaviour>();
         public IEnumerable<ContractBehaviour> Behaviours { get { return behaviours.AsReadOnly(); } }
 
+		public static string contractTypeName(Contract c)
+		{
+			try
+			{
+				ConfiguredContract CC = (ConfiguredContract)c;
+				if (CC.contractType != null)
+				{
+					return CC.contractType.name;
+				}
+				else
+				{
+					return "";
+				}
+			}
+			catch (Exception e)
+			{
+				Debug.LogWarning("Something something can't cast to type + " e);
+				return "";
+			}
+		}
+
         protected string title;
         protected string description;
         protected string synopsis;


### PR DESCRIPTION
Too late for another addition?

This will make it much simpler to determine the Contract Configurator contract type for any given contract that comes back with GetType() == "ConfiguredContract".