### PR TITLE
Check contractType status before accessing it for these two methods

### DIFF
--- a/source/ContractConfigurator/ConfiguredContract.cs
+++ b/source/ContractConfigurator/ConfiguredContract.cs
@@ -181,12 +181,12 @@ namespace ContractConfigurator
 
         public override bool CanBeCancelled()
         {
-            return contractType.cancellable;
+            return contractType != null ? contractType.cancellable : true;
         }
 
         public override bool CanBeDeclined()
         {
-            return contractType.declinable;
+            return contractType != null ? contractType.declinable : true;
         }
 
         protected override string GetHashString()


### PR DESCRIPTION
CapCom was choking on these two methods when the contractType was missing for some reason. There are ways of getting around it on my end, but it's probably best to check for this anyway.