### PR TITLE
Fix random cancellation of accepted contracts

### DIFF
--- a/source/ContractConfigurator/ConfiguredContract.cs
+++ b/source/ContractConfigurator/ConfiguredContract.cs
@@ -444,14 +444,15 @@ namespace ContractConfigurator
             if (contractType != null)
             {
                 bool meets = contractType.MeetRequirements(this);
-                if (ContractState == State.Active && !meets) {
+                if (ContractState == State.Active && !meets)
+                {
                     LoggingUtil.LogWarning(this, "Removed contract '" + title + "', as it no longer meets the requirements.");
                 }
                 return meets;
             }
-            // Special case for pre-loader
             else if (ContractState == State.Withdrawn)
             {
+                // Special case for pre-loader
                 return true;
             }
             // No ContractType chosen

--- a/source/ContractConfigurator/ConfiguredContract.cs
+++ b/source/ContractConfigurator/ConfiguredContract.cs
@@ -440,28 +440,23 @@ namespace ContractConfigurator
 
         public override bool MeetRequirements()
         {
-            // Special case for pre-loader
-            if (ContractState == State.Withdrawn)
+            // ContractType already chosen, check if still meets requirements.
+            if (contractType != null)
             {
-                return true;
-            }
-
-            // No ContractType chosen
-            if (contractType == null)
-            {
-                LoggingUtil.LogVerbose(this, "MeetRequirements()");
-                return ContractPreLoader.Instance.GenerateContract(this);
-            }
-            else 
-            {
-                // ContractType already chosen, check if still meets requirements.
                 bool meets = contractType.MeetRequirements(this);
-                if (ContractState == State.Active && !meets)
-                {
+                if (ContractState == State.Active && !meets) {
                     LoggingUtil.LogWarning(this, "Removed contract '" + title + "', as it no longer meets the requirements.");
                 }
                 return meets;
             }
+            // Special case for pre-loader
+            else if (ContractState == State.Withdrawn)
+            {
+                return true;
+            }
+            // No ContractType chosen
+            LoggingUtil.LogVerbose(this, "MeetRequirements()");
+            return ContractPreLoader.Instance.GenerateContract(this);
         }
 
         public override string MissionControlTextRich()


### PR DESCRIPTION
Verify contracts are still valid (for example maxCompletion checks) before offering them from the preloader.

HistoricMissions has a bunch of contracts with `maxCompletions = 1` (`maxConcurrent` is unset). Every once in a while, an accepted contract will disappear, or i'll see a newly offered contract flash and then disappear.

In logs I see:
```
[LOG 12:27:15.871] [DEBUG] ContractConfigurator.ContractType: Cancelling contract of type Sputnik-3 (Sputnik-3): Too many completed/active/offered contracts.
[WRN 12:27:15.872] ContractConfigurator.ConfiguredContract: Removed contract 'Sputnik-3', as it no longer meets the requirements.
```

So it looks like what happens is this:

1. Two contracts of the same name with `maxCompleted = 1` are preloaded
2. The checks in `ContractType.MeetRequirements()` for `maxCompleted`/`maxConcurrent` for the 2nd one aren't tripped since neither are offered yet
3. `ContractPreLoader.GetNextContract()` calls `ConfiguredContract.MeetRequirements()` - this returns true due to the short circuit at the start, and the 1st contract is now offered (and possibly accepted).
4. Same happens for the 2nd contract, and there are two "active" contracts of the same name, yet `maxCompleted = 1`.
5. One of the contracts is then canceled - depending on which gets `MeetRequirements()` called on it first.

With this change I can no longer reproduce this behaviour.