### PR TITLE
Revert "Fix inverted cooldownDuration logic"

### DIFF
--- a/source/ContractConfigurator/ContractRequirement/CompleteContractRequirement.cs
+++ b/source/ContractConfigurator/ContractRequirement/CompleteContractRequirement.cs
@@ -92,7 +92,7 @@ namespace ContractConfigurator
             }
 
             // Check cooldown
-            if (cooldownDuration.Value > 0.0 && finished > 0 && lastFinished + cooldownDuration.Value <= Planetarium.GetUniversalTime())
+            if (cooldownDuration.Value > 0.0 && finished > 0 && lastFinished + cooldownDuration.Value > Planetarium.GetUniversalTime())
             {
                 LoggingUtil.LogDebug(this, "Returning false due to cooldown for " + contractType.name);
                 return false;


### PR DESCRIPTION
Reverts jrossignol/ContractConfigurator#246

Bah it was correct originally; I was just seeing that other bug and I thought it was this.

My apologies!