### PR TITLE
Fixed base opened/closed requirements text.

### DIFF
--- a/source/KerKonConConExt/Requirements/BaseClosedRequirement.cs
+++ b/source/KerKonConConExt/Requirements/BaseClosedRequirement.cs
@@ -35,7 +35,7 @@ namespace KerKonConConExt
 
         protected override string RequirementText()
         {
-            string output = "Must " + (invertRequirement ? "not have opened " : "have opened") + " base <color=#" + MissionControlUI.RequirementHighlightColor + ">'" + basename + "'</color>";
+            string output = "Base <color=#" + MissionControlUI.RequirementHighlightColor + ">'" + basename + "'</color> must " + (!invertRequirement ? "not be opened" : "be opened");
             return output;
         }
     }

--- a/source/KerKonConConExt/Requirements/BaseOpenRequirement.cs
+++ b/source/KerKonConConExt/Requirements/BaseOpenRequirement.cs
@@ -35,7 +35,7 @@ namespace KerKonConConExt
 
         protected override string RequirementText()
         {
-            string output = "Must " + (!invertRequirement ? "not have opened " : "have opened") + " base <color=#" + MissionControlUI.RequirementHighlightColor + ">'" + basename + "'</color>";
+            string output = "Base <color=#" + MissionControlUI.RequirementHighlightColor + ">'" + basename + "'</color> must " + (invertRequirement ? "not be opened" : "be opened");
             return output;
         }
     }


### PR DESCRIPTION
I used BaseOpen requirement in my contract and saw "Must not have  base <name> opened" as a requirement text. So I checked the code and yes, the texts are inverted ("must not" when really "must").

Here is the pull-request to fix it and bring the texts in accordance with the other KerKonConConExt Requirement classes.