### PR TITLE
Allow for more characters in celestialbody names

### DIFF
--- a/source/ContractConfigurator/ExpressionParser/Parsers/Classes/CelestialBodyParser.cs
+++ b/source/ContractConfigurator/ExpressionParser/Parsers/Classes/CelestialBodyParser.cs
@@ -233,7 +233,7 @@ namespace ContractConfigurator.ExpressionParser
         public override CelestialBody ParseIdentifier(Token token)
         {
             // Try to parse more, as celestibla body names can have spaces
-            Match m = Regex.Match(expression, @"^((?>\s*[\w\d]+)+).*");
+            Match m = Regex.Match(expression, @"^((?>\s*[\w\d\-\/\']+)+).*");
             string identifier = m.Groups[1].Value;
             expression = (expression.Length > identifier.Length ? expression.Substring(identifier.Length) : "");
             identifier = token.sval + identifier;


### PR DESCRIPTION
This should fix https://github.com/jrossignol/ContractConfigurator/issues/642 although this is just a fix for the current available planetpacks in galactic neighbourhood. If anyone decides to use some other character in their planet name this problem will resurface.

Is it really necessary to parse celestialbody's through regex?