### PR TITLE
Read day/year length from dateTimeFormatter

### DIFF
--- a/source/ContractConfigurator/Util/DurationUtil.cs
+++ b/source/ContractConfigurator/Util/DurationUtil.cs
@@ -119,10 +119,10 @@ namespace ContractConfigurator
 
             if (GameSettings.KERBIN_TIME)
             {
-                SecondsPerYear = 9201600;  // = 426d
-                SecondsPerDay = 21600;     // = 6h
-                SecondsPerHour = 3600;     // = 60m
-                SecondsPerMinute = 60;     // = 60s
+                SecondsPerYear = (uint)KSPUtil.dateTimeFormatter.Year;
+                SecondsPerDay = (uint)KSPUtil.dateTimeFormatter.Day;
+                SecondsPerHour = (uint)KSPUtil.dateTimeFormatter.Hour;
+                SecondsPerMinute = (uint)KSPUtil.dateTimeFormatter.Minute;
             }
         }
 


### PR DESCRIPTION
To help support non-standard day/year lengths from custom planet packs
or system rescales, prefer use of KSPUtil.dateTimeFormatter.

Compiled DLL for testing:  [ContractConfigurator.zip](https://github.com/jrossignol/ContractConfigurator/files/1584975/ContractConfigurator.zip)

