### PR TITLE
Add new IsInRadioBlackout function to the fake satelite

### DIFF
--- a/source/CC_RemoteTech/RemoteTechProgressTracker.cs
+++ b/source/CC_RemoteTech/RemoteTechProgressTracker.cs
@@ -62,6 +62,7 @@ namespace ContractConfigurator.RemoteTech
             public bool HasLocalControl { get { return true; } }
 
             public bool CanRelaySignal { get { return false; } }
+            public bool IsInRadioBlackout { get; set; }
 
             /// <summary>
             /// Indicates whether the ISatellite corresponds to a vessel


### PR DESCRIPTION
Compensates for this change in remote tech:

https://github.com/RemoteTechnologiesGroup/RemoteTech/commit/ddb3edf18d46ee1605c1f46befebd4bd8a63dde3

I've tested this on my save and my contracts reappeared. Thanks for making and maintaining this mod!