### PR TITLE
Increase the maximum contract limit multiplier to 20

### DIFF
--- a/source/ContractConfigurator/SettingsBuilder.cs
+++ b/source/ContractConfigurator/SettingsBuilder.cs
@@ -40,7 +40,7 @@ namespace ContractConfigurator
         public bool DisplayOfferedWaypoints = ContractDefs.DisplayOfferedWaypoints;
         public bool DisplayActiveWaypoints = true;
 
-        [GameParameters.CustomFloatParameterUI("Active Contract Multiplier", displayFormat = "F2", minValue = 0.1f, maxValue = 2.0f, stepCount = 20,
+        [GameParameters.CustomFloatParameterUI("Active Contract Multiplier", displayFormat = "F2", minValue = 0.1f, maxValue = 20.0f, stepCount = 50,
             toolTip = "Multiplier applied to the active contract limits.")]
         public float ActiveContractMultiplier = 1.0f;
 


### PR DESCRIPTION
Fixes #634

Also increases the resolution of the slider since there are more values.

Not sure if this was desired outside of a few of us, but saw the report of someone else wanting it and figured I'd submit a PR. My feelings wont be hurt if you reject it and have purposely chosen 2 as the max multiplier, the issue didn't have any responses negative or positive so I assume leaving it open is a positive.