### PR TITLE
Fix for GPP to display Gael in correct case

### DIFF
--- a/source/ContractConfigurator/Util/Extensions.cs
+++ b/source/ContractConfigurator/Util/Extensions.cs
@@ -269,7 +269,7 @@ namespace ContractConfigurator
             strArr[0] = body.GetDisplayName();
             string displayName = KSP.Localization.Localizer.Format("<<1>>", strArr);
 
-            if (lower && displayName != body.name)
+            if (lower && displayName != body.name && displayName != "Gael")
             {
                 displayName = Char.ToLowerInvariant(displayName[0]) + displayName.Substring(1);
             }


### PR DESCRIPTION
At present because Gael's display name is Gael but it's body name is Kerbin it displays Gael in lowercase. This would stop this from happening.