### PR TITLE
Fixed celestial body progress requirements with checkType (MANNED/UNMANNED)

### DIFF
--- a/source/ContractConfigurator/Requirement/ProgressCelestialBodyRequirement.cs
+++ b/source/ContractConfigurator/Requirement/ProgressCelestialBodyRequirement.cs
@@ -44,19 +44,21 @@ namespace ContractConfigurator
             checkType = ConfigNodeUtil.ParseValue<CheckType?>(configNode, "checkType", (CheckType?)null);
         }
 
-        protected CelestialBodySubtree GetCelestialBodySubtree()
+        protected ProgressNode GetCelestialBodySubtree()
         {
             // Get the progress tree for our celestial body
             foreach (var node in ProgressTracking.Instance.celestialBodyNodes)
             {
                 if (node.Body == targetBody)
                 {
-                    return node;
+                    return GetTypeSpecificProgressNode(node);
                 }
             }
 
             return null;
         }
+
+        protected abstract ProgressNode GetTypeSpecificProgressNode(CelestialBodySubtree celestialBodySubtree);
 
         public override bool RequirementMet(ConfiguredContract contract)
         {
@@ -67,7 +69,7 @@ namespace ContractConfigurator
             }
 
             // Validate the CelestialBodySubtree exists
-            CelestialBodySubtree cbProgress = GetCelestialBodySubtree();
+            ProgressNode cbProgress = GetCelestialBodySubtree();
             if (cbProgress == null)
             {
                 LoggingUtil.LogError(this, ": ProgressNode for targetBody " + targetBody.bodyName + " not found.");

--- a/source/ContractConfigurator/Requirement/ProgressCelestialBodyRequirement/BaseConstructionRequirement.cs
+++ b/source/ContractConfigurator/Requirement/ProgressCelestialBodyRequirement/BaseConstructionRequirement.cs
@@ -13,10 +13,16 @@ namespace ContractConfigurator
     /// </summary>
     public class BaseConstructionRequirement : ProgressCelestialBodyRequirement
     {
-        public override bool RequirementMet(ConfiguredContract contract)
+
+		protected override ProgressNode GetTypeSpecificProgressNode(CelestialBodySubtree celestialBodySubtree)
+		{
+            return celestialBodySubtree.baseConstruction;
+		}
+
+		public override bool RequirementMet(ConfiguredContract contract)
         {
             return base.RequirementMet(contract) &&
-                GetCelestialBodySubtree().baseConstruction.IsComplete;
+                GetCelestialBodySubtree().IsComplete;
         }
 
         protected override string RequirementText()

--- a/source/ContractConfigurator/Requirement/ProgressCelestialBodyRequirement/DockingRequirement.cs
+++ b/source/ContractConfigurator/Requirement/ProgressCelestialBodyRequirement/DockingRequirement.cs
@@ -13,10 +13,15 @@ namespace ContractConfigurator
     /// </summary>
     public class DockingRequirement : ProgressCelestialBodyRequirement
     {
+        protected override ProgressNode GetTypeSpecificProgressNode(CelestialBodySubtree celestialBodySubtree)
+        {
+            return celestialBodySubtree.docking;
+        }
+
         public override bool RequirementMet(ConfiguredContract contract)
         {
             return base.RequirementMet(contract) &&
-                GetCelestialBodySubtree().docking.IsComplete;
+                GetCelestialBodySubtree().IsComplete;
         }
 
         protected override string RequirementText()

--- a/source/ContractConfigurator/Requirement/ProgressCelestialBodyRequirement/EscapeRequirement.cs
+++ b/source/ContractConfigurator/Requirement/ProgressCelestialBodyRequirement/EscapeRequirement.cs
@@ -13,10 +13,15 @@ namespace ContractConfigurator
     /// </summary>
     public class EscapeRequirement : ProgressCelestialBodyRequirement
     {
+        protected override ProgressNode GetTypeSpecificProgressNode(CelestialBodySubtree celestialBodySubtree)
+        {
+            return celestialBodySubtree.escape;
+        }
+
         public override bool RequirementMet(ConfiguredContract contract)
         {
             return base.RequirementMet(contract) &&
-                GetCelestialBodySubtree().escape.IsComplete;
+                GetCelestialBodySubtree().IsComplete;
         }
 
         protected override string RequirementText()

--- a/source/ContractConfigurator/Requirement/ProgressCelestialBodyRequirement/FlyByRequirement.cs
+++ b/source/ContractConfigurator/Requirement/ProgressCelestialBodyRequirement/FlyByRequirement.cs
@@ -13,11 +13,15 @@ namespace ContractConfigurator
     /// </summary>
     public class FlyByRequirement : ProgressCelestialBodyRequirement
     {
+        protected override ProgressNode GetTypeSpecificProgressNode(CelestialBodySubtree celestialBodySubtree)
+        {
+            return celestialBodySubtree.flyBy;
+        }
+
         public override bool RequirementMet(ConfiguredContract contract)
         {
-            CelestialBodySubtree tree = GetCelestialBodySubtree();
-            return base.RequirementMet(contract) && tree.flyBy != null &&
-                tree.flyBy.IsComplete;
+            return base.RequirementMet(contract) &&
+                GetCelestialBodySubtree().IsComplete;
         }
 
 

--- a/source/ContractConfigurator/Requirement/ProgressCelestialBodyRequirement/LandingRequirement.cs
+++ b/source/ContractConfigurator/Requirement/ProgressCelestialBodyRequirement/LandingRequirement.cs
@@ -13,10 +13,15 @@ namespace ContractConfigurator
     /// </summary>
     public class LandingRequirement : ProgressCelestialBodyRequirement
     {
+        protected override ProgressNode GetTypeSpecificProgressNode(CelestialBodySubtree celestialBodySubtree)
+        {
+            return celestialBodySubtree.landing;
+        }
+
         public override bool RequirementMet(ConfiguredContract contract)
         {
             return base.RequirementMet(contract) &&
-                GetCelestialBodySubtree().landing.IsComplete;
+                GetCelestialBodySubtree().IsComplete;
         }
 
         protected override string RequirementText()

--- a/source/ContractConfigurator/Requirement/ProgressCelestialBodyRequirement/OrbitRequirement.cs
+++ b/source/ContractConfigurator/Requirement/ProgressCelestialBodyRequirement/OrbitRequirement.cs
@@ -13,10 +13,15 @@ namespace ContractConfigurator
     /// </summary>
     public class OrbitRequirement : ProgressCelestialBodyRequirement
     {
+        protected override ProgressNode GetTypeSpecificProgressNode(CelestialBodySubtree celestialBodySubtree)
+        {
+            return celestialBodySubtree.orbit;
+        }
+
         public override bool RequirementMet(ConfiguredContract contract)
         {
             return base.RequirementMet(contract) &&
-                GetCelestialBodySubtree().orbit.IsComplete;
+                GetCelestialBodySubtree().IsComplete;
         }
 
         protected override string RequirementText()

--- a/source/ContractConfigurator/Requirement/ProgressCelestialBodyRequirement/RendezvousRequirement.cs
+++ b/source/ContractConfigurator/Requirement/ProgressCelestialBodyRequirement/RendezvousRequirement.cs
@@ -13,10 +13,15 @@ namespace ContractConfigurator
     /// </summary>
     public class RendezvousRequirement : ProgressCelestialBodyRequirement
     {
+        protected override ProgressNode GetTypeSpecificProgressNode(CelestialBodySubtree celestialBodySubtree)
+        {
+            return celestialBodySubtree.rendezvous;
+        }
+
         public override bool RequirementMet(ConfiguredContract contract)
         {
             return base.RequirementMet(contract) &&
-                GetCelestialBodySubtree().rendezvous.IsComplete;
+                GetCelestialBodySubtree().IsComplete;
         }
 
         protected override string RequirementText()

--- a/source/ContractConfigurator/Requirement/ProgressCelestialBodyRequirement/ReturnFromFlyByRequirement.cs
+++ b/source/ContractConfigurator/Requirement/ProgressCelestialBodyRequirement/ReturnFromFlyByRequirement.cs
@@ -13,11 +13,15 @@ namespace ContractConfigurator
     /// </summary>
     public class ReturnFromFlyByRequirement : ProgressCelestialBodyRequirement
     {
+        protected override ProgressNode GetTypeSpecificProgressNode(CelestialBodySubtree celestialBodySubtree)
+        {
+            return celestialBodySubtree.returnFromFlyby;
+        }
+
         public override bool RequirementMet(ConfiguredContract contract)
         {
-            CelestialBodySubtree tree = GetCelestialBodySubtree();
-            return base.RequirementMet(contract) && tree.returnFromFlyby != null &&
-                tree.returnFromFlyby.IsComplete;
+            return base.RequirementMet(contract) &&
+				GetCelestialBodySubtree().IsComplete;
         }
 
         protected override string RequirementText()

--- a/source/ContractConfigurator/Requirement/ProgressCelestialBodyRequirement/ReturnFromOrbitRequirement.cs
+++ b/source/ContractConfigurator/Requirement/ProgressCelestialBodyRequirement/ReturnFromOrbitRequirement.cs
@@ -13,10 +13,15 @@ namespace ContractConfigurator
     /// </summary>
     public class ReturnFromOrbitRequirement : ProgressCelestialBodyRequirement
     {
+        protected override ProgressNode GetTypeSpecificProgressNode(CelestialBodySubtree celestialBodySubtree)
+        {
+            return celestialBodySubtree.returnFromOrbit;
+        }
+
         public override bool RequirementMet(ConfiguredContract contract)
         {
             return base.RequirementMet(contract) &&
-                GetCelestialBodySubtree().returnFromOrbit.IsComplete;
+                GetCelestialBodySubtree().IsComplete;
         }
 
         protected override string RequirementText()

--- a/source/ContractConfigurator/Requirement/ProgressCelestialBodyRequirement/ReturnFromSurfaceRequirement.cs
+++ b/source/ContractConfigurator/Requirement/ProgressCelestialBodyRequirement/ReturnFromSurfaceRequirement.cs
@@ -14,6 +14,11 @@ namespace ContractConfigurator
     /// </summary>
     public class ReturnFromSurfaceRequirement : ProgressCelestialBodyRequirement
     {
+        protected override ProgressNode GetTypeSpecificProgressNode(CelestialBodySubtree celestialBodySubtree)
+        {
+            return celestialBodySubtree.returnFromSurface;
+        }
+
         public override bool LoadFromConfig(ConfigNode configNode)
         {
             // Load base class
@@ -26,7 +31,7 @@ namespace ContractConfigurator
         {
             // This appears bugged - returnFromSurface is null
             return base.RequirementMet(contract) &&
-                GetCelestialBodySubtree().returnFromSurface.IsComplete;
+                GetCelestialBodySubtree().IsComplete;
         }
 
         protected override string RequirementText()

--- a/source/ContractConfigurator/Requirement/ProgressCelestialBodyRequirement/SplashDownRequirement.cs
+++ b/source/ContractConfigurator/Requirement/ProgressCelestialBodyRequirement/SplashDownRequirement.cs
@@ -13,10 +13,15 @@ namespace ContractConfigurator
     /// </summary>
     public class SplashDownRequirement : ProgressCelestialBodyRequirement
     {
+        protected override ProgressNode GetTypeSpecificProgressNode(CelestialBodySubtree celestialBodySubtree)
+        {
+            return celestialBodySubtree.splashdown;
+        }
+
         public override bool RequirementMet(ConfiguredContract contract)
         {
             return base.RequirementMet(contract) &&
-                GetCelestialBodySubtree().splashdown.IsComplete;
+                GetCelestialBodySubtree().IsComplete;
         }
 
         protected override string RequirementText()

--- a/source/ContractConfigurator/Requirement/ProgressCelestialBodyRequirement/SurfaceEVARequirement.cs
+++ b/source/ContractConfigurator/Requirement/ProgressCelestialBodyRequirement/SurfaceEVARequirement.cs
@@ -13,10 +13,15 @@ namespace ContractConfigurator
     /// </summary>
     public class SurfaceEVARequirement : ProgressCelestialBodyRequirement
     {
+        protected override ProgressNode GetTypeSpecificProgressNode(CelestialBodySubtree celestialBodySubtree)
+        {
+            return celestialBodySubtree.surfaceEVA;
+        }
+
         public override bool RequirementMet(ConfiguredContract contract)
         {
             return base.RequirementMet(contract) &&
-                GetCelestialBodySubtree().surfaceEVA.IsComplete;
+                GetCelestialBodySubtree().IsComplete;
         }
 
         protected override string RequirementText()


### PR DESCRIPTION
When using a `checkType` (`MANNED` / `UNMANNED`), the basic check in the abstract class `ProgressCelestialBodyRequirement` fails _always_.

The reason is that CelestialBodySubtree has IsCompleteManned and IsCompleteUnmanned members, but those must not be checked for manned/unmanned specific tests for progress requirements.

Looking at CelestialBodySubtree.IsCompleteManned is wrong when you want to be looking at
things like CelestialBodySubtree.orbit.IsCompleteManned.

(Using KSP 1.9.1, but I doubt that this was a recent change in KSP)