### PR TITLE
Check for null in OnPartJointBreak

### DIFF
--- a/source/ContractConfigurator/Parameter/VesselParameter/VesselNotDestroyed.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/VesselNotDestroyed.cs
@@ -112,6 +112,11 @@ namespace ContractConfigurator.Parameters
             base.OnPartJointBreak(p, breakForce);
 
             Vessel v = p.Parent.vessel;
+            if (v == null)
+            {
+                LoggingUtil.LogDebug(this, "OnPartJointBreak: p.Parent.vessel was null");
+                return;
+            }
             LoggingUtil.LogVerbose(this, "OnPartJointBreak: {0}", v.id);
             if (v.vesselType == VesselType.Debris)
             {


### PR DESCRIPTION
In the VAB, for some reason probably related to automatic autostrutting,
ContractConfigurator starts throwing NullReferenceExceptions of the type

```
[EXC 23:10:42.742] NullReferenceException: Object reference not set to an instance of an object
        ContractConfigurator.Parameters.VesselNotDestroyed.OnPartJointBreak (PartJoint p, System.Single breakForce) (at <ef0243a06f2841fe9bf57034a334902e>:0)
        EventData`2[T,U].Fire (T data0, U data1) (at <dc0e5f458c0f4571ad839b9c4153f347>:0)
        UnityEngine.DebugLogHandler:LogException(Exception, Object)
        ModuleManager.UnityLogHandle.InterceptLogHandler:LogException(Exception, Object)
        UnityEngine.Debug:LogException(Exception)
        EventData`2:Fire(PartJoint, Single)
        PartJoint:DestroyJoint()
        Part:ReleaseAutoStruts()
        Part:onDetach(Boolean)
        Part:onDetach(Boolean)
        EditorLogic:detachPart(Part)
        EditorLogic:<SetupFSM>b__190_21()
        KerbalFSM:RunEvent(KFSMEvent)
        KerbalFSM:updateFSM(KFSMUpdateMode)
        KerbalFSM:UpdateFSM()
        EditorLogic:Update()
```

Because for some reason OnPartJointBreak gets called on a `PartJoint p`
for which `p.Parent.vessel` returns null.

This is reproducible on my config with normal decouplers, but the most
reliable way of reproducing it I've found is:

0. Start a new vehicle in the VAB.
1. Select a Mk1-3 command pod as the root.
2. Put an engine plate (SquadExpansion) on the bottom.
3. Put an engine on the engine plate.
4. "Pick up" the engine plate.
5. Observe the VAB stutter while the log gets filled with these
   exceptions.

This happens on an old save file which I've been coaxing into working
with the current install, but I *have* done a complete reinstall of all
my mods and it happens on a *new* craft, not just existing ones. I have
not tested it in a clean save file because I figure the fix is worth
doing anyway.