### PR TITLE
Fix ResourceConsumptionChecker, would break on part count change

### DIFF
--- a/source/ContractConfigurator/Parameter/VesselParameter/ResourceConsuption.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/ResourceConsuption.cs
@@ -64,6 +64,7 @@ namespace ContractConfigurator.Parameters
                 // Reset counter on vessel change
                 if (partCount != localCount)
                 {
+                    partCount = localCount;
                     checks = 0;
                 }
 


### PR DESCRIPTION
Checks was reset when the active vessel's part count did not match the stored part count, but the stored part count was only updated on vessel switch, not when the local count of parts changed. Added missing line. This should fix a bug we are experiencing in RP-1 right now.

cc @siimav