### PR TITLE
ContractCheckRequirement optimizations

### DIFF
--- a/source/ContractConfigurator/Requirement/CompleteContractRequirement.cs
+++ b/source/ContractConfigurator/Requirement/CompleteContractRequirement.cs
@@ -43,6 +43,12 @@ namespace ContractConfigurator
 
         public override bool RequirementMet(ConfiguredContract contract)
         {
+            if (ccType != null && contract?.ContractState == Contract.State.Active && maxCount == uint.MaxValue && !invertRequirement)
+            {
+                // If the contract is already accepted and there's no maxCount limit then these checks can never go back to false again.
+                return true;
+            }
+
             // Get the count of finished contracts
             int finished = 0;
             double lastFinished = 0.0;

--- a/source/ContractConfigurator/Requirement/ContractCheckRequirement.cs
+++ b/source/ContractConfigurator/Requirement/ContractCheckRequirement.cs
@@ -24,11 +24,13 @@ namespace ContractConfigurator
             // Load base class
             bool valid = base.LoadFromConfig(configNode);
 
-            checkOnActiveContract = true;
-
             // Get type
             string contractType = null;
             valid &= ConfigNodeUtil.ParseValue<string>(configNode, "contractType", x => contractType = x, this);
+
+            // By default, always check the requirement for active contracts
+            valid &= ConfigNodeUtil.ParseValue<bool>(configNode, "checkOnActiveContract", x => checkOnActiveContract = x, this, true);
+
             if (valid)
             {
                 valid &= SetValues(contractType);
@@ -70,6 +72,7 @@ namespace ContractConfigurator
         {
             configNode.AddValue("minCount", minCount);
             configNode.AddValue("maxCount", maxCount);
+            configNode.AddValue("checkOnActiveContract", checkOnActiveContract);
             if (ccType != null)
             {
                 configNode.AddValue("contractType", ccType);


### PR DESCRIPTION
This is related to #710. The issue is that `RequirementMet` method in `AcceptContractRequirement` and `CompleteContractRequirement` is run every Update. This will cause nontrivial overhead when there's a lot of contracts accepted and/or completed. I'm not quite sure what's the best way to optimize that code but I noticed that in some cases these checks aren't actually relevant at all. For example if the contract requires that another contract needs to be completed before it can be offered, this check can never go back to `false` again after accepting it. This is why I would like to explicitly specify on some contracts that this requirement is no longer relevant after it has been accepted.